### PR TITLE
Command mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: tmouche <tmouche@student.42.fr>            +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/07/15 17:21:22 by thibaud           #+#    #+#              #
-#    Updated: 2024/12/09 17:52:51 by tmouche          ###   ########.fr        #
+#    Updated: 2024/12/13 16:42:00 by tmouche          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -21,7 +21,7 @@ HEADER		=	hdrs/
 SRCS_DIR	=	srcs/
 OBJS_DIR	=	.objs/
 DEPS_DIR	=	.deps/
-SRCS		=	main.cpp Server.cpp Client.cpp message.cpp Channel.cpp Command.cpp
+SRCS		=	main.cpp Server.cpp ServerMode.cpp ServerSend.cpp Client.cpp message.cpp Channel.cpp Command.cpp 
 
 
 OBJS		= $(SRCS:%.cpp=$(OBJS_DIR)%.o)

--- a/hdrs/Channel.class.hpp
+++ b/hdrs/Channel.class.hpp
@@ -6,7 +6,7 @@
 /*   By: tmouche <tmouche@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/29 17:37:21 by tmouche           #+#    #+#             */
-/*   Updated: 2024/12/01 19:33:15 by tmouche          ###   ########.fr       */
+/*   Updated: 2024/12/10 17:57:55 by tmouche          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,8 +26,11 @@ typedef enum	e_channelType {
 class Channel {
 public:
 
-	void			sendToChannel(int const clientID, std::string const message);
+	void			sendToChannel(std::string const message);
 	bool			isOperator(int const clientID);
+	bool			isClient(int const clientID);
+	void			addOperator(int const clientID);
+	void			deleteOperator(int const clientID);
 
 	t_channelType const		_channelType;
 	std::string const		_channelName;

--- a/hdrs/Command.class.hpp
+++ b/hdrs/Command.class.hpp
@@ -6,7 +6,7 @@
 /*   By: tmouche <tmouche@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/02 17:15:18 by tmouche           #+#    #+#             */
-/*   Updated: 2024/12/10 12:34:23 by tmouche          ###   ########.fr       */
+/*   Updated: 2024/12/10 15:01:32 by tmouche          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,7 +33,7 @@ class Client;
 class Command {
 public:
 	~Command( void );
-	Command(std::string const & rawLine);
+	Command(std::string const & rawLine, int const clientID);
 
 	std::string					getPrefix( void );
 	std::string					getCommand( void );
@@ -41,6 +41,7 @@ public:
 	std::string					getMessage( void );
 	std::vector<std::string>	getTargetChannels( void );
 	std::vector<t_user*>		getTargetUsers( void );
+	std::vector<t_mode*>		getMode( void );
 	
 private:
 	Command( void );
@@ -60,6 +61,7 @@ private:
 	void	setINVITE(std::vector<std::string> splitedLine, int idx);
 	// void	setQUIT(std::vector<std::string> splitedLine, int idx);
 
+	int const					_clientID;
 	std::string					_rawLine;
 
 	std::string					_prefix;

--- a/hdrs/Command.class.hpp
+++ b/hdrs/Command.class.hpp
@@ -6,7 +6,7 @@
 /*   By: tmouche <tmouche@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/02 17:15:18 by tmouche           #+#    #+#             */
-/*   Updated: 2024/12/10 15:01:32 by tmouche          ###   ########.fr       */
+/*   Updated: 2024/12/10 15:55:59 by tmouche          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,7 +33,7 @@ class Client;
 class Command {
 public:
 	~Command( void );
-	Command(std::string const & rawLine, int const clientID);
+	Command(std::string const & rawLine);
 
 	std::string					getPrefix( void );
 	std::string					getCommand( void );
@@ -61,7 +61,6 @@ private:
 	void	setINVITE(std::vector<std::string> splitedLine, int idx);
 	// void	setQUIT(std::vector<std::string> splitedLine, int idx);
 
-	int const					_clientID;
 	std::string					_rawLine;
 
 	std::string					_prefix;

--- a/hdrs/Command.class.hpp
+++ b/hdrs/Command.class.hpp
@@ -6,7 +6,7 @@
 /*   By: tmouche <tmouche@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/02 17:15:18 by tmouche           #+#    #+#             */
-/*   Updated: 2024/12/10 15:55:59 by tmouche          ###   ########.fr       */
+/*   Updated: 2024/12/13 16:34:48 by tmouche          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,7 @@ typedef struct s_user {
 typedef struct s_mode {
 	unsigned int				sign;
 	char						mode;
-	std::vector<std::string>	args;
+	std::string					args;
 }	t_mode;
 
 class Client;

--- a/hdrs/Error.define.hpp
+++ b/hdrs/Error.define.hpp
@@ -6,7 +6,7 @@
 /*   By: tmouche <tmouche@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/29 13:38:55 by tmouche           #+#    #+#             */
-/*   Updated: 2024/12/09 17:56:25 by tmouche          ###   ########.fr       */
+/*   Updated: 2024/12/10 15:45:21 by tmouche          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,120 +14,114 @@
 # define ERROR_DEFINE_HPP
 # include <string>
 
-std::string	ERR_NOSUCHNICK(std::string const nickname) {return (nickname + " :No such nick/channel");} 
-// 401 Used to indicate the nickname parameter supplied to a command is currently
+# define	ERR_NOSUCHNICK(nickname) ("401 :" + (nickname) + " :No such nick/channel\r\n")
+// Used to indicate the nickname parameter supplied to a command is currently
 // unused.
 
-std::string	ERR_NOSUCHCHANNEL(std::string const channelName) {return (channelName + " :No such channel");}
-// 403 Used to indicate the given channel name is invalid
+# define ERR_NOSUCHCHANNEL(channel) ("403 :" + (channel) + " :No such channel\r\n")
+// Used to indicate the given channel name is invalid
 
-std::string	ERR_TOOMANYCHANNELS(std::string const channelName) {return (channelName + " :You have joined too many channels");}
-// 405 Sent to a user when they have joined the maximum number of allowed channels
+# define ERR_TOOMANYCHANNELS(channel) ("405 :" + (channel) + " :You have joined too many channels\r\n")
+// Sent to a user when they have joined the maximum number of allowed channels
 // and they try to join another channel.
 
-std::string	ERR_TOOMANYTARGETS(std::string const target) {return (target + " :Duplicate recipients. No message delivered");}
-// 407 Returned to a client which is attempting to send a PRIVMSG/NOTICE using the
+# define ERR_TOOMANYTARGETS(target) ("407 :" + (target) + " :Duplicate recipients. No message delivered\r\n")
+// Returned to a client which is attempting to send a PRIVMSG/NOTICE using the
 // user@host destination format and for a user@host which has several occurrences.
 
-std::string	ERR_UNKNOWNCOMMAND(std::string const command) {return (command + " :Unknown command");}
-// 421 Returned to a registered client to indicate that the command send unknown
+# define ERR_UNKNOWNCOMMAND(command) ("421 :" + (command) + " :Unknown command\r\n")
+// Returned to a registered client to indicate that the command send unknown
 // by the server
 
-std::string	ERR_NONICKNAMEGIVEN( void ) {return ":No nickname given";}
-// 431 Returned when a nickname parameter expected for a command and isn't found.
+# define ERR_NONICKNAMEGIVEN "431 :No Nickname given\r\n"
+// Returned when a nickname parameter expected for a command and isn't found.
 
-std::string	ERR_ERRONEUSNICKNAME(std::string const nick) {return (nick + " :Erroneus nickname");}
-// 432 Returned after receiving a NICK message which contains characters which do
+# define ERR_ERRONEUSNICKNAME(nickname) ("432 :" + (nickname) + " :Erroneus nickname\r\n")
+// Returned after receiving a NICK message which contains characters which do
 // not fall in the defined set. See section x.x.x for details on valid nicknames.
 
-std::string	ERR_NICKNAMEINUSE(std::string const nick) {return (nick + " :Nickname is already in use");} 
-// 433 Returned when a NICK message is processed that results in an attempt to
+# define ERR_NICKNAMEINUSE(nickname) ("433 :" + (nickname) + " :Nickname is already in use\r\n")
+// Returned when a NICK message is processed that results in an attempt to
 // change to a currently existing nickname.
 
-std::string	ERR_NICKCOLLISION(std::string const nick) {return (nick + " :Nickname collision KILL");}
-// 436 Returned by a server to a client when it detects a nickname collision
+# define ERR_NICKCOLLISION(nickname) ("436 :" + (nickname) +  ":Nickname collision KILL\r\n")
+// Returned by a server to a client when it detects a nickname collision
 // (registered of a NICK that already exists by another server).
 
-std::string	ERR_USERNOTINCHANNEL(std::string const nick, std::string channel) {return (nick + " " + channel + " :They aren't on that channel");}
-// 441 Returned by the server to indicate that the targer user of the commande is
+# define ERR_USERNOTINCHANNEL(nickname, channel) ("441 :" + (nickname) + " " + (channel) + " :They aren't on that channel\r\n")
+// Returned by the server to indicate that the targer user of the commande is
 // not on the given channel
 
-std::string	ERR_NOTONCHANNEL(std::string const channel) {return (channel + " :You're not on that channel");}
-// 442 Returned by the server whenever a client tries to preform a channel effecting
+# define ERR_NOTONCHANNEL(channel) ("442 :" + (channel) + " :You're not on that channel\r\n")
+// Returned by the server whenever a client tries to preform a channel effecting
 // command for which to client isn't a member.
 
-std::string	ERR_USERONCHANNEL(std::string const user, std::string channel) {return (user + " " + channel + " :is already on channel");}
+# define ERR_USERONCHANNEL(username, channel) ("443 :" + (user) + " " + (channel) + " :is already on channel\r\n")
 // 443 Returned when a client tries to invite a user to a channel they are already on.
 
-std::string	ERR_SUMMONDISABLED( void ) {return ":SUMMON has been disabled";}
-// 445 Returned as a response to the SUMMON command. Must be returned by any server
+# define ERR_SUMMONDISABLED "445 :SUMMON has been disabled\r\n"
+// Returned as a response to the SUMMON command. Must be returned by any server
 // which does not implement it. 
 
-std::string	ERR_USERSDISABLED( void ) {return ":USERS has been disabled";}
-// 446 Returned as a response to the USERS command.  Must be returned by any server
+# define ERR_USERSDISABLED "446 :USERS has been disabled\r\n"
+// Returned as a response to the USERS command.  Must be returned by any server
 // which does not implement it.
 
-std::string	ERR_NOTREGISTRATED( void ) {return ":You have not registered";}
-// 451 Returned by the server to indicate that the client must be registered before
+# define ERR_NOTREGISTRATED "451 :You have not registered\r\n"
+// Returned by the server to indicate that the client must be registered before
 // the server will allow it to be parsed in detail.
 
-std::string	ERR_NEEDMOREPARAMS(std::string const command) {return (command + " :Not enough parameters");}
-// 461 Returned by the server by numerous commands to indicate to the client that
+# define ERR_NEEDMOREPARAMS(command) ("461 :" + (command) + " :Not enough parameters\r\n")
+// Returned by the server by numerous commands to indicate to the client that
 // it didn't supply enough parameters.
 
-std::string	ERR_ALREADYREGISTRED( void ) {return ":You may not reregister";}
-// 462 Returned by the server to any link which tries to change part of the
+# define ERR_ALREADYREGISTRED "462 :You may not reregister\r\n"
+// Returned by the server to any link which tries to change part of the
 // registered details (such as password or user details from second USER message).
 
-std::string	ERR_PASSWDMISMATCH( void ) {return ":Password incorrect";}
-// 464 Returned to indicate a failed attempt at registering a connection for which
+# define ERR_PASSWDMISMATCH "464 :Password incorrect\r\n"
+// Returned to indicate a failed attempt at registering a connection for which
 // a password was required and was either not given or incorrect.
 
-std::string	ERR_YOUREBANNEDCREEP( void ) {return ":You are banned from this server";}
-// 465 Returned after an attempt to connect and register yourself with a server
+# define ERR_YOUREBANNEDCREEP "465 :You are banned from this server\r\n"
+// Returned after an attempt to connect and register yourself with a server
 // which has been setup to explicitly deny connections to you.
 
-std::string	ERR_KEYSET(std::string const channel) {return (channel + " :Channel key already set");}
-// 467
+# define ERR_KEYSET(channel) ("467 :" + (channel) + " :Channel key already set\r\n") 
 
-std::string	ERR_CHANNELISFULL(std::string const channel) {return (channel + " :Cannot join channel (+l)");}
-// 471
+# define ERR_CHANNELISFULL(channel) ("471 :" + (channel) + " :Cannot join channel (+l)\r\n")
 
-std::string	ERR_UNKNOWNMODE(std::string const c) {return (c + " :is unknown mode char to me");}
-// 472
+# define ERR_UNKNOWNMODE(char) ("472 :" + (char) +  ":is unknown mode char to me\r\n") 
 
-std::string	ERR_INVITEONLYCHAN(std::string const channel) {return (channel + " :Cannot join channel (+i)");}
-// 473
+# define ERR_INVITEONLYCHAN(channel) ("473 :" + (channel) + " :Cannot join channel (+i)\r\n")
 
-std::string	ERR_BANNEDFROMCHAN(std::string const channel) {return (channel + " :Cannot join channel (+b)");}
-// 474 
+# define ERR_BANNEDFROMCHAN(channel) ("474 :" + (channel) + " :Cannot join channel (+b)\r\n")
 
-std::string	ERR_BADCHANNELKEY(std::string const channel) {return (channel + " :Cannot join channel (+k)");}
-// 475
+# define ERR_BADCHANNELKEY(channel) ("475 :" + (channel) + " :Cannot join channel (+k)\r\n")
 
-std::string	ERR_NOPRIVILEGES( void ) {return ":Permission Denied- You're not an IRC operator";}
-// 481 Any command requiring operator privileges to operate must return this
+# define ERR_NOPRIVILEGES "481 :Permission Denied- You're not an IRC operator\r\n"
+// Any command requiring operator privileges to operate must return this
 // error to indicate the attempt was unsuccessful.
 
-std::string	ERR_CHANOPRIVSNEEDED(std::string const channel) {return (channel + " :You're not channel operator");}
-// 482 Any command requiring 'chanop' privileges (such as MODE messages) must
+# define ERR_CHANOPRIVSNEEDED(channel) ("482 :" + (channel) + " :You're not channel operator\r\n")
+// Any command requiring 'chanop' privileges (such as MODE messages) must
 // return this error if the client making the attempt is not a chanop on the
 // specified channel.
 
-std::string	ERR_CANTKILLSERVER( void ) {return ":You cant kill a server!";}
-// 483 Any attempts to use the KILL command on a server are to be refused and
+# define ERR_CANTKILLSERVER "483 :You cant kill a server!\r\n"
+// Any attempts to use the KILL command on a server are to be refused and
 // this error returned directly to the client.
 
-std::string	ERR_NOOPERHOST( void ) {return ":No O-lines for your host";} 
-// 491 If a client sends an OPER message and the server has not been configured
+# define ERR_NOOPERHOST "491 :No O-lines for your host\r\n"
+// If a client sends an OPER message and the server has not been configured
 // to allow connections from the client's host as an operator, this error must be returned.
 
-std::string	ERR_UMODEUNKNOWNFLAG( void ) {return ":Unknown MODE flag";}
-// 501 Returned by the server to indicate that a MODE message was sent with a
+# define ERR_UMODEUNKNOWNFLAG "501 :Unknown MODE flag\r\n"
+// Returned by the server to indicate that a MODE message was sent with a
 // nickname parameter and that the a mode flag sent was not recognized.
 
-std::string	ERR_USERSDONTMATCH( void ) {return ":Cant change mode for other users";}
-// 502 Error sent to any user trying to view or change the user mode for a user
+# define ERR_USERSDONTMATCH "502 :Cant change mode for other users\r\n"
+// Error sent to any user trying to view or change the user mode for a user
 // other than themselves.
 
 #endif

--- a/hdrs/Error.define.hpp
+++ b/hdrs/Error.define.hpp
@@ -6,7 +6,7 @@
 /*   By: tmouche <tmouche@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/29 13:38:55 by tmouche           #+#    #+#             */
-/*   Updated: 2024/12/10 15:45:21 by tmouche          ###   ########.fr       */
+/*   Updated: 2024/12/13 17:01:18 by tmouche          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -91,7 +91,7 @@
 
 # define ERR_CHANNELISFULL(channel) ("471 :" + (channel) + " :Cannot join channel (+l)\r\n")
 
-# define ERR_UNKNOWNMODE(char) ("472 :" + (char) +  ":is unknown mode char to me\r\n") 
+# define ERR_UNKNOWNMODE(mode) ("472 :" + (mode) +  ":is unknown mode char to me\r\n") 
 
 # define ERR_INVITEONLYCHAN(channel) ("473 :" + (channel) + " :Cannot join channel (+i)\r\n")
 

--- a/hdrs/Reply.define.hpp
+++ b/hdrs/Reply.define.hpp
@@ -6,7 +6,7 @@
 /*   By: tmouche <tmouche@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/29 15:23:27 by tmouche           #+#    #+#             */
-/*   Updated: 2024/11/29 15:31:06 by tmouche          ###   ########.fr       */
+/*   Updated: 2024/12/10 15:52:30 by tmouche          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,35 +16,28 @@
 #define RPL_NONE
 // 300 Dummy reply number. Not used.
 
-#define RPL_AWAY(nick, awayMessage) nick" :"awayMessage
-// 301
+#define RPL_AWAY(nick, awayMessage) ("301 :" + (nick) + " :" + (awayMessage) + "\r\n")
 
-#define RPL_UNAWAY ":You are no longer marked as being away"
-// 305
+#define RPL_UNAWAY "305 :You are no longer marked as being away\r\n"
 
-#define RPL_NOWAWAY ":You have been marked as being away"
-// 306 - 305 These replies are used with the AWAY command (if allowed).
+#define RPL_NOWAWAY " 306 :You have been marked as being away\r\n"
+// These replies are used with the AWAY command (if allowed).
 // RPL_AWAY is sent to any client sending a PRIVMSG to a client which is away.
 // RPL_AWAY is only sent by the server to which the client is connected. Replies
 // RPL_UNAWAY and RPL_NOWAWAY are sent when the client removes and sets an AWAY message.
 
-#define RPL_WHOISUSER(nick, user, host, realName) nick" "user" "host" * :"realName
-// 311
+#define RPL_WHOISUSER(nick, user, host, realName) ("311 :" + (nick) + " " + (user) + " "+ (host) + " * :" + (realName) + "\r\n")
 
-#define RPL_WHOISSERVER(nick, server, serverInfo) nick" "server" "serverInfo
-// 312
+#define RPL_WHOISSERVER(nick, server, serverInfo) ("312 :" + (nick) + " " + (server) + " " + (serverInfo) + "\r\n")
 
-#define RPL_WHOISOPERATOR(nick) nick": is an IRC operator"
-// 313
+#define RPL_WHOISOPERATOR(nick) ("313 :" + (nick) + ": is an IRC operator\r\n")
 
-#define RPL_WHOISIDLE(nick, integer) nick" "integer" :seconds idle"
-// 317
+#define RPL_WHOISIDLE(nick, integer) ("317 :" + (nick) + " " + (integer) + " :seconds idle\r\n")
 
-#define RPL_ENDOFWHOIS(nick) nick" :End of /WHOIS list"
-// 318
+#define RPL_ENDOFWHOIS(nick) ("318 :" + (nick) + " :End of /WHOIS list\r\n")
 
-#define RPL_WHOISCHANNELS(nick, channel, space) nick " :{[@|+]"channel" "space"}"
-// 319 Replies 311 - 313, 317 - 319 are all replies
+#define RPL_WHOISCHANNELS(nick, channel, space) ("319 :" + (nick) + " :{[@|+]" + (channel) + " " + (space) + "}\r\n")
+// are all replies
 // generated in response to a WHOIS message.  Given that
 // there are enough parameters present, the answering
 // server must either formulate a reply out of the above
@@ -60,20 +53,18 @@
 // the end of processing a WHOIS message.
 
 
-#define RPL_CHANNELMODEIS(channel, mode, modeParams) channel" "mode" "modeParams
-// 324
+#define RPL_CHANNELMODEIS(channel, mode, modeParams) ("324 :" + (channel) + " " + (mode) + " " + (modeParams) + "\r\n")
 
-#define RPL_NOTOPIC(channel) channel" :No topic is set"
-// 331
+#define RPL_NOTOPIC(channel) ("331 :" + (channel) + " :No topic is set\r\n")
 
-#define RPL_TOPIC(channel, topic) channel" :"topic
-// 332 When sending a TOPIC message to determine the
+#define RPL_TOPIC(channel, topic) ("332 :" + (channel) + " :" + (topic) + "\r\n")
+// When sending a TOPIC message to determine the
 // channel topic, one of two replies is sent.  If
 // the topic is set, RPL_TOPIC is sent back else
 // RPL_NOTOPIC.
 
-#define RPL_INVITING(channel, nick) channel" "nick
-// 341 Returned by the server to indicate that the
+#define RPL_INVITING(channel, nick) ("341 :" + (channel) + " " + (nick) + "\r\n")
+// Returned by the server to indicate that the
 // attempted INVITE message was successful and is
 // being passed onto the end client.
 

--- a/hdrs/Server.class.hpp
+++ b/hdrs/Server.class.hpp
@@ -6,7 +6,7 @@
 /*   By: tmouche <tmouche@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/27 17:43:48 by tmouche           #+#    #+#             */
-/*   Updated: 2024/12/09 17:53:18 by tmouche          ###   ########.fr       */
+/*   Updated: 2024/12/10 14:51:24 by tmouche          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,6 +18,7 @@
 #include "Channel.class.hpp"
 
 # include <map>
+# include <vector>
 # include <string>
 # include <sys/epoll.h>
 
@@ -41,15 +42,8 @@ public:
 	void			LegacysendToChannel(std::string channelName, int clientID, std::string message);
 	void			LegacysendToServer(int clientID, std::string message);
 
-	void			processCommand(Command* command);
 
-	void			sendToConsole(int clientID, std::string message);
-	void			sendToServer(int clientID, std::string message);
-	void			sendToChannel(int clientID, std::string channelName, std::string message);
-	void			sendToClient(int clientID, int targetID, std::string message);
 	
-	void			addChannel(t_channelType channelType, std::string channelName);
-	void			eraseChannel(std::string channelName);
 
 
 private:
@@ -57,8 +51,18 @@ private:
 	Server(Server const & src);
 	Server&	operator=(Server const & rhs);
 
+	void	processCommand(Command* command);
+	void	MODE(Command* command);
+	
+	void	sendToConsole(int clientID, std::string message);
+	void	sendToServer(int clientID, std::string message);
+	void	sendToChannel(int clientID, std::string channelName, std::string message);
+	void	sendToClient(int clientID, int targetID, std::string message);
+
 	void	addClient( void );
 	void	eraseClient(int clientID);
+	void	addChannel(t_channelType channelType, std::string channelName);
+	void	eraseChannel(std::string channelName);
 
 	std::string const	_serverName;
 

--- a/hdrs/Server.class.hpp
+++ b/hdrs/Server.class.hpp
@@ -6,7 +6,7 @@
 /*   By: tmouche <tmouche@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/27 17:43:48 by tmouche           #+#    #+#             */
-/*   Updated: 2024/12/10 14:51:24 by tmouche          ###   ########.fr       */
+/*   Updated: 2024/12/10 17:50:14 by tmouche          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,7 +35,7 @@ public:
 
 	void			startServer(int port);
 	void			runServer( void );
-	void			sendError(int ClientId, int codeError, const std::string& msgError);
+	void			sendError(int const ClientId, std::string const & msgError);
 
 	void			serverRequest(int clientID, std::string rawLine);
 
@@ -52,7 +52,13 @@ private:
 	Server&	operator=(Server const & rhs);
 
 	void	processCommand(Command* command);
-	void	MODE(Command* command);
+	
+	void	MODE(Command* command, int clientID);
+	void	MODEt(struct s_mode const * currentMode, Channel * const currentChannel, int const clientID);
+	void	MODEi(struct s_mode const * currentMode, Channel * const currentChannel, int const clientID);
+	void	MODEl(struct s_mode const * currentMode, Channel * const currentChannel, int const clientID);
+	void	MODEk(struct s_mode const * currentMode, Channel * const currentChannel, int const clientID);
+	void	MODEo(struct s_mode const * currentMode, Channel * const currentChannel, int const clientID);
 	
 	void	sendToConsole(int clientID, std::string message);
 	void	sendToServer(int clientID, std::string message);

--- a/srcs/Channel.cpp
+++ b/srcs/Channel.cpp
@@ -6,7 +6,7 @@
 /*   By: tmouche <tmouche@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/29 18:02:50 by tmouche           #+#    #+#             */
-/*   Updated: 2024/12/02 17:03:48 by tmouche          ###   ########.fr       */
+/*   Updated: 2024/12/10 17:58:39 by tmouche          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -62,12 +62,9 @@ void	Channel::uninstantiateChannel(Channel* oldChannel) {
 	return ;
 }
 
-void	Channel::sendToChannel(int const clientID, std::string const message) {
+void	Channel::sendToChannel(std::string const message) {
 	for (std::map<int, Client*>::iterator it = this->_channelClient.begin(); it != this->_channelClient.end(); it++) {
-		if (it->first != clientID) {
-			int otherClient = it->second->_clientID;
-			send(otherClient, message.c_str(), message.size(), 0);
-		}
+		send(it->second->_clientID, message.c_str(), message.size(), 0);
 	}
 	return ;
 }
@@ -76,4 +73,20 @@ bool	Channel::isOperator(int const clientID) {
 	if (this->_channelOperator[clientID])
 		return true;
 	return false;
+}
+
+bool	Channel::isClient(int const clientID) {
+	if (this->_channelClient[clientID])
+		return true;
+	return false;
+}
+
+void	Channel::addOperator(int const clientID) {
+	this->_channelOperator[clientID] = this->_channelClient[clientID];
+	return ;
+}
+
+void	Channel::deleteOperator(int const clientID) {
+	this->_channelOperator.erase(clientID);
+	return ;
 }

--- a/srcs/Command.cpp
+++ b/srcs/Command.cpp
@@ -6,7 +6,7 @@
 /*   By: tmouche <tmouche@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/02 17:26:46 by tmouche           #+#    #+#             */
-/*   Updated: 2024/12/10 17:28:00 by tmouche          ###   ########.fr       */
+/*   Updated: 2024/12/13 16:36:29 by tmouche          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -154,8 +154,8 @@ void	Command::setMODE(std::vector<std::string> splitedLine, int idx) {
 				this->_mode.push_back(newMode);
 			}
 		}
-		else if (!this->_mode.empty())
-			this->_mode.back()->args.push_back(splitedLine[idx]);
+		else if (!this->_mode.empty() && this->_mode.back()->args.empty())
+			this->_mode.back()->args = splitedLine[idx];
 	}
 	return ;
 }

--- a/srcs/Command.cpp
+++ b/srcs/Command.cpp
@@ -6,7 +6,7 @@
 /*   By: tmouche <tmouche@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/02 17:26:46 by tmouche           #+#    #+#             */
-/*   Updated: 2024/12/10 12:47:26 by tmouche          ###   ########.fr       */
+/*   Updated: 2024/12/10 15:03:16 by tmouche          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@
 
 #include <iostream>
 
-Command::Command( void ) {
+Command::Command( void ) : _clientID(0) {
 	return ;
 }
 
@@ -27,7 +27,7 @@ Command::~Command( void ) {
 	return ;
 }
 
-Command::Command(std::string const & rawLine) {
+Command::Command(std::string const & rawLine, int const clientID) : _clientID(clientID) {
 	this->_rawLine = rawLine;
 	this->_cmdMethods["PASS"] = &Command::setPASS;
 	this->_cmdMethods["NICK"] = &Command::setNICK;
@@ -42,7 +42,7 @@ Command::Command(std::string const & rawLine) {
 	return ;
 }
 
-Command::Command(Command const & src) {
+Command::Command(Command const & src) : _clientID(src._clientID) {
 	(void)src;
 	return ;
 }
@@ -190,6 +190,10 @@ std::vector<std::string>	Command::getTargetChannels( void ) {
 	return this->_targetChannels;
 }
 
-std::vector<t_user *>	Command::getTargetUsers( void ) {
+std::vector<t_user*>	Command::getTargetUsers( void ) {
 	return this->_targetUsers;
 }
+
+std::vector<t_mode*>	Command::getMode( void ) {
+	return this->_mode;
+}	

--- a/srcs/Command.cpp
+++ b/srcs/Command.cpp
@@ -6,7 +6,7 @@
 /*   By: tmouche <tmouche@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/02 17:26:46 by tmouche           #+#    #+#             */
-/*   Updated: 2024/12/10 15:03:16 by tmouche          ###   ########.fr       */
+/*   Updated: 2024/12/10 17:28:00 by tmouche          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@
 
 #include <iostream>
 
-Command::Command( void ) : _clientID(0) {
+Command::Command( void ) {
 	return ;
 }
 
@@ -27,7 +27,7 @@ Command::~Command( void ) {
 	return ;
 }
 
-Command::Command(std::string const & rawLine, int const clientID) : _clientID(clientID) {
+Command::Command(std::string const & rawLine) {
 	this->_rawLine = rawLine;
 	this->_cmdMethods["PASS"] = &Command::setPASS;
 	this->_cmdMethods["NICK"] = &Command::setNICK;
@@ -42,7 +42,7 @@ Command::Command(std::string const & rawLine, int const clientID) : _clientID(cl
 	return ;
 }
 
-Command::Command(Command const & src) : _clientID(src._clientID) {
+Command::Command(Command const & src) {
 	(void)src;
 	return ;
 }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: tmouche <tmouche@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/27 17:46:54 by tmouche           #+#    #+#             */
-/*   Updated: 2024/12/09 18:48:55 by tmouche          ###   ########.fr       */
+/*   Updated: 2024/12/10 15:06:43 by tmouche          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -132,7 +132,7 @@ void	Server::LegacysendToChannel(std::string const channelName, int const client
 }
 
 void	Server::serverRequest(int clientID, std::string rawLine) {
-	Command		myCommand(rawLine);
+	Command		myCommand(rawLine, clientID);
 
 	sendToConsole(clientID, rawLine);
 	processCommand(&myCommand);
@@ -143,6 +143,16 @@ void	Server::processCommand(Command* command) {
 	(void)command;
 	return ;
 }
+
+void	Server::MODE(Command* command) {
+	std::vector<t_mode*> const	allMode = command->getMode();
+
+	Channel const *	currentChannel = this->_serverChannel[command->getTargetChannels().front()];	
+	if (!currentChannel) {
+		
+	}
+}
+
 
 void	Server::sendToConsole(int clientID, std::string message) {
 	std::string const	prefix = ":" + this->_serverClient[clientID]->_nickname + "!" + this->_serverClient[clientID]->_username + "@" + this->_serverName;

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: tmouche <tmouche@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/27 17:46:54 by tmouche           #+#    #+#             */
-/*   Updated: 2024/12/10 15:06:43 by tmouche          ###   ########.fr       */
+/*   Updated: 2024/12/10 18:02:42 by tmouche          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,7 @@
 #include <sys/epoll.h>
 #include <string.h>
 #include <sstream>
+#include <cstdlib>
 
 Server*	Server::_me = nullptr;
 
@@ -127,12 +128,12 @@ void	Server::LegacysendToChannel(std::string const channelName, int const client
 	if (this->_serverChannel[channelName]->isOperator(clientID))
 		line += "@";
 	line += (this->_serverClient[clientID]->_nickname + ": " + token);
-	this->_serverChannel[channelName]->sendToChannel(clientID, line);
+	this->_serverChannel[channelName]->sendToChannel(line);
 	return ;
 }
 
 void	Server::serverRequest(int clientID, std::string rawLine) {
-	Command		myCommand(rawLine, clientID);
+	Command		myCommand(rawLine);
 
 	sendToConsole(clientID, rawLine);
 	processCommand(&myCommand);
@@ -144,13 +145,94 @@ void	Server::processCommand(Command* command) {
 	return ;
 }
 
-void	Server::MODE(Command* command) {
+void	Server::MODE(Command* command, int const clientID) {
 	std::vector<t_mode*> const	allMode = command->getMode();
-
-	Channel const *	currentChannel = this->_serverChannel[command->getTargetChannels().front()];	
+	std::string	const			nameTargetChannel = command->getTargetChannels().front();
+	Channel * const				currentChannel = this->_serverChannel[nameTargetChannel];
+	
 	if (!currentChannel) {
-		
+		this->sendToClient(this->_mySocket, clientID, ERR_NOSUCHCHANNEL(nameTargetChannel));
+		return ;
 	}
+	std::vector<t_mode*>	allModes = command->getMode();
+	std::map<char,void(Server::*)(t_mode const *, Channel * const , int const)> _modeCmd;
+	_modeCmd['t'] = &Server::MODEt;
+	_modeCmd['i'] = &Server::MODEi;
+	_modeCmd['l'] = &Server::MODEl;
+	_modeCmd['k'] = &Server::MODEk;
+	_modeCmd['o'] = &Server::MODEo;
+	int const	size = allModes.size();
+	for (int idx = 0; idx < size; idx++) {
+		t_mode*	currentMode = allModes[idx];
+		void (Server::*func)(t_mode const *, Channel * const , int const) = _modeCmd[currentMode->mode];
+		if (func)
+			(this->*func)(currentMode, currentChannel, clientID);
+	}
+}
+
+void	Server::MODEt(t_mode const * currentMode, Channel * const currentChannel, int const clientID) {
+	if (!currentChannel->isOperator(clientID)) {
+		this->sendToClient(this->_mySocket, clientID, ERR_CHANOPRIVSNEEDED(currentChannel->_channelName));
+		return ;
+	}
+	currentChannel->_topicMode = currentMode->sign % 5;
+	return ;
+}
+
+void	Server::MODEi(t_mode const * currentMode, Channel * const currentChannel, int const clientID) {
+	if (!currentChannel->isOperator(clientID)) {
+		this->sendToClient(this->_mySocket, clientID, ERR_CHANOPRIVSNEEDED(currentChannel->_channelName));
+		return ;
+	}
+	currentChannel->_inviteOnlyMode = currentMode->sign % 5;
+	return ;
+}
+
+void	Server::MODEl(t_mode const * currentMode, Channel * const currentChannel, int const clientID) {
+	if (!currentChannel->isOperator(clientID)) {
+		this->sendToClient(this->_mySocket, clientID, ERR_CHANOPRIVSNEEDED(currentChannel->_channelName));
+		return ;
+	}
+	if (currentMode->sign == '+')
+		currentChannel->_channelLimit = std::atoi(currentMode->args.front().c_str());
+	else if (currentMode->sign == '-')
+		currentChannel->_channelLimit = -1;
+	return ;
+}
+
+void	Server::MODEk(t_mode const * currentMode, Channel * const currentChannel, int const clientID) {
+	if (!currentChannel->isOperator(clientID)) {
+		this->sendToClient(this->_mySocket, clientID, ERR_CHANOPRIVSNEEDED(currentChannel->_channelName));
+		return ;
+	}
+	if (currentMode->sign == '+')
+		currentChannel->_channelPassword = currentMode->args.front();
+	else if (currentMode->sign == '-')
+		currentChannel->_channelPassword = "";
+	return ;
+}
+
+void	Server::MODEo(t_mode const * currentMode, Channel * const currentChannel, int const clientID) {
+	if (!currentChannel->isOperator(clientID)) {
+		this->sendToClient(this->_mySocket, clientID, ERR_CHANOPRIVSNEEDED(currentChannel->_channelName));
+		return ;
+	}
+	int const	targetID = std::atoi(currentMode->args.front().c_str());
+	if (!currentChannel->isClient(targetID)) {
+		// ERR
+		return ;
+	}
+	if (currentMode->sign == '+')
+		currentChannel->addOperator(targetID);
+	else if (currentMode->sign == '-') {
+		if (currentChannel->isOperator(targetID))
+			currentChannel->deleteOperator(targetID);
+		else {
+			// ERR
+			return ;
+		}
+	}
+	return ; 
 }
 
 
@@ -175,7 +257,7 @@ void	Server::sendToServer(int clientID, std::string message) {
 void	Server::sendToChannel(int clientID, std::string channelName, std::string message) {
 	std::string const	line = this->_serverClient[clientID]->_nickname + " " + message;
 	
-	this->_serverChannel[channelName]->sendToChannel(clientID, message);
+	this->_serverChannel[channelName]->sendToChannel(message);
 	return ;
 }
 
@@ -256,13 +338,9 @@ void	Server::Factory::deleteChannel(Channel* oldChannel) {
 	return ;
 }
 
-void	Server::sendError(int clientId, int codeError, const std::string& msgError)
+void	Server::sendError(int const clientId, std::string const & msgError)
 {
-	std::stringstream 	message;
-
-	message << ":" << this->_address->sin_addr.s_addr << " "
-			<< codeError << " " << this->_serverClient[clientId]->_nickname
-			<< msgError << std::endl;
-	if (send(clientId, message.str().c_str(), message.str().length(), 0) == -1)
+	if (send(clientId, msgError.c_str(), msgError.size(), 0) == -1)
 		throw SendException();
+	return ;
 }

--- a/srcs/ServerMode.cpp
+++ b/srcs/ServerMode.cpp
@@ -6,7 +6,7 @@
 /*   By: tmouche <tmouche@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/13 16:10:51 by tmouche           #+#    #+#             */
-/*   Updated: 2024/12/13 16:38:58 by tmouche          ###   ########.fr       */
+/*   Updated: 2024/12/13 17:17:42 by tmouche          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,6 +41,11 @@ void	Server::MODE(Command* command, int const clientID) {
 		void (Server::*func)(t_mode const *, Channel * const , int const) = _modeCmd[currentMode->mode];
 		if (func)
 			(this->*func)(currentMode, currentChannel, clientID);
+		else {
+			std::string error;
+			error[0] = currentMode->mode;
+			this->sendToClient(this->_mySocket, clientID, ERR_UNKNOWNMODE(error));
+		}
 	}
 }
 

--- a/srcs/ServerMode.cpp
+++ b/srcs/ServerMode.cpp
@@ -1,0 +1,120 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ServerMode.cpp                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tmouche <tmouche@student.42.fr>            +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/12/13 16:10:51 by tmouche           #+#    #+#             */
+/*   Updated: 2024/12/13 16:38:58 by tmouche          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "Server.class.hpp"
+#include "Exception.class.hpp"
+#include "Client.class.hpp"
+#include "Channel.class.hpp"
+#include "Error.define.hpp"
+#include "Command.class.hpp"
+
+#include <cstdlib>
+
+void	Server::MODE(Command* command, int const clientID) {
+	std::vector<t_mode*> const	allMode = command->getMode();
+	std::string	const			nameTargetChannel = command->getTargetChannels().front();
+	Channel * const				currentChannel = this->_serverChannel[nameTargetChannel];
+	
+	if (!currentChannel) {
+		this->sendToClient(this->_mySocket, clientID, ERR_NOSUCHCHANNEL(nameTargetChannel));
+		return ;
+	}
+	std::vector<t_mode*>	allModes = command->getMode();
+	std::map<char,void(Server::*)(t_mode const *, Channel * const , int const)> _modeCmd;
+	_modeCmd['t'] = &Server::MODEt;
+	_modeCmd['i'] = &Server::MODEi;
+	_modeCmd['l'] = &Server::MODEl;
+	_modeCmd['k'] = &Server::MODEk;
+	_modeCmd['o'] = &Server::MODEo;
+	int const	size = allModes.size();
+	for (int idx = 0; idx < size; idx++) {
+		t_mode*	currentMode = allModes[idx];
+		void (Server::*func)(t_mode const *, Channel * const , int const) = _modeCmd[currentMode->mode];
+		if (func)
+			(this->*func)(currentMode, currentChannel, clientID);
+	}
+}
+
+void	Server::MODEt(t_mode const * currentMode, Channel * const currentChannel, int const clientID) {
+	if (!currentChannel->isOperator(clientID)) {
+		this->sendToClient(this->_mySocket, clientID, ERR_CHANOPRIVSNEEDED(currentChannel->_channelName));
+		return ;
+	}
+	currentChannel->_topicMode = currentMode->sign % 5 % 2;
+	std::string const	reply = "MODE " + currentChannel->_channelName + static_cast<char>(currentMode->sign) + "t";
+	this->sendToChannel(0, currentChannel->_channelName, reply);
+	return ;
+}
+
+void	Server::MODEi(t_mode const * currentMode, Channel * const currentChannel, int const clientID) {
+	if (!currentChannel->isOperator(clientID)) {
+		this->sendToClient(this->_mySocket, clientID, ERR_CHANOPRIVSNEEDED(currentChannel->_channelName));
+		return ;
+	}
+	currentChannel->_inviteOnlyMode = currentMode->sign % 5 % 2;
+	std::string const	reply = "MODE " + currentChannel->_channelName + static_cast<char>(currentMode->sign) + "i";
+	this->sendToChannel(0, currentChannel->_channelName, reply);
+	return ;
+}
+
+void	Server::MODEl(t_mode const * currentMode, Channel * const currentChannel, int const clientID) {
+	if (!currentChannel->isOperator(clientID)) {
+		this->sendToClient(this->_mySocket, clientID, ERR_CHANOPRIVSNEEDED(currentChannel->_channelName));
+		return ;
+	}
+	std::string reply = "MODE " + currentChannel->_channelName + static_cast<char>(currentMode->sign) + "l";
+	if (currentMode->sign == '+') {
+		currentChannel->_channelLimit = std::atoi(currentMode->args.c_str());
+		reply += (" " + currentMode->args);
+	}
+	else if (currentMode->sign == '-')
+		currentChannel->_channelLimit = -1;
+	this->sendToChannel(0, currentChannel->_channelName, reply);
+	return ;
+}
+
+void	Server::MODEk(t_mode const * currentMode, Channel * const currentChannel, int const clientID) {
+	if (!currentChannel->isOperator(clientID)) {
+		this->sendToClient(this->_mySocket, clientID, ERR_CHANOPRIVSNEEDED(currentChannel->_channelName));
+		return ;
+	}
+	if (currentMode->sign == '+')
+		currentChannel->_channelPassword = currentMode->args;
+	else if (currentMode->sign == '-')
+		currentChannel->_channelPassword = "";
+	std::string const	reply = "MODE " + currentChannel->_channelName + static_cast<char>(currentMode->sign) + "k";
+	this->sendToChannel(0, currentChannel->_channelName, reply);
+	return ;
+}
+
+void	Server::MODEo(t_mode const * currentMode, Channel * const currentChannel, int const clientID) {
+	if (!currentChannel->isOperator(clientID)) {
+		this->sendToClient(this->_mySocket, clientID, ERR_CHANOPRIVSNEEDED(currentChannel->_channelName));
+		return ;
+	}
+	int const	targetID = std::atoi(currentMode->args.c_str());
+	if (!currentChannel->isClient(targetID)) {
+		this->sendToClient(this->_mySocket, clientID, ERR_USERNOTINCHANNEL(currentMode->args, currentChannel->_channelName));
+		return ;
+	}
+	if (currentMode->sign == '+')
+		currentChannel->addOperator(targetID);
+	else if (currentMode->sign == '-') {
+		if (currentChannel->isOperator(targetID))
+			currentChannel->deleteOperator(targetID);
+		else
+			return ;
+	}
+	std::string const	reply = "MODE " + currentChannel->_channelName + static_cast<char>(currentMode->sign) + "o " + currentMode->args;
+	this->sendToChannel(0, currentChannel->_channelName, reply);
+	return ; 
+}

--- a/srcs/ServerSend.cpp
+++ b/srcs/ServerSend.cpp
@@ -1,0 +1,46 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ServerSend.cpp                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tmouche <tmouche@student.42.fr>            +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/12/13 16:39:52 by tmouche           #+#    #+#             */
+/*   Updated: 2024/12/13 16:41:28 by tmouche          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <sys/socket.h>
+#include "Server.class.hpp"
+
+void	Server::sendToConsole(int clientID, std::string message) {
+	std::string const	prefix = ":" + this->_serverClient[clientID]->_nickname + "!" + this->_serverClient[clientID]->_username + "@" + this->_serverName;
+	std::string const	line = prefix + " " + message;
+
+	send(this->_console->_clientID, line.c_str(), line.size(), 0); // pb ca marche pas j ai essaye d envoyer le this->_mySocket mais ca plante, la on est sur une valeur fix de 1, le std::cout marche bien mais jsp j aime pas
+	return ;
+}
+
+void	Server::sendToServer(int clientID, std::string message) {
+	std::string const	line = this->_serverClient[clientID]->_nickname + " " + message;
+
+	for (std::map<int, Client *>::iterator it = this->_serverClient.begin(); it != this->_serverClient.end(); it++) {
+		int otherClient = it->second->_clientID;
+		send(otherClient, line.c_str(), line.size(), 0);
+	}
+	return ;
+}
+
+void	Server::sendToChannel(int clientID, std::string channelName, std::string message) {
+	std::string const	line = this->_serverClient[clientID]->_nickname + " " + message;
+	
+	this->_serverChannel[channelName]->sendToChannel(message);
+	return ;
+}
+
+void	Server::sendToClient(int clientID, int targetID, std::string message) {
+	std::string const	line = this->_serverClient[clientID]->_nickname + " " + message;
+
+	send(targetID, line.c_str(), line.size(), 0);
+	return ;
+}


### PR DESCRIPTION
This pull request is about the adding of the command MODE with all of their mandatory options (t, o, i, l and k). I developed it in a simple way. Firstly we check if the option exist, if not ERR_UNKNOWNMODE is send.
After we check if the client who try to use the mode is operator in the current channel, if he is not the ERR_CHANOPRIVSNEEDED is send. Now the command is process and do what it is built for, the reply to announce what has been change is send to the the whole Channel, it looks like : MODE <channelName> <option> <arg>.
The error file has been fixed, there is no more functions in it and the defines are correctly working as expected.